### PR TITLE
chore: Upgrade to latest i18n required npm remove/install @nuxtjs/i18n

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -2,9 +2,9 @@ name: Scan deployed images with Trivy
 
 # Controls when the action will run.
 on:
-  #schedule:
-    # At 12:29 on day-of-month 8
-    # - cron: '29 12 8 * *'
+  schedule:
+    # At 12:03 on Wednesday.
+    - cron: '3 12 * * 3'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ logs
 .DS_Store
 .fleet
 .idea
+cypress/screenshots
 
 # Local env files
 .env

--- a/local-dev/compose.yml
+++ b/local-dev/compose.yml
@@ -12,3 +12,12 @@ services:
       - KC_BOOTSTRAP_ADMIN_PASSWORD=change_me
     ports:
       - "8080:8080"
+
+  marvel:
+    image: docker.io/mockoon/cli
+    command: --data /data/mock-api.json --port 4513
+    restart: always
+    volumes:
+      - ./mock:/data:ro
+    ports:
+      - "4513:4513"

--- a/local-dev/mock/mock-api.json
+++ b/local-dev/mock/mock-api.json
@@ -1,6 +1,6 @@
 {
   "uuid": "b44755ae-ecc9-4c28-ae1d-72e60db3f0ed",
-  "lastMigration": 32,
+  "lastMigration": 33,
   "name": "Mock marvel api for use with hello carbon nuxt project.",
   "endpointPrefix": "",
   "latency": 2000,
@@ -175,7 +175,9 @@
           "callbacks": []
         }
       ],
-      "responseMode": null
+      "responseMode": null,
+      "streamingMode": null,
+      "streamingInterval": 0
     },
     {
       "uuid": "817f4c01-e157-4b72-8510-fa96cd544af5",
@@ -209,7 +211,9 @@
           "callbacks": []
         }
       ],
-      "responseMode": null
+      "responseMode": null,
+      "streamingMode": null,
+      "streamingInterval": 0
     },
     {
       "uuid": "3e240a94-809e-45a6-84c1-4ab25a3389ef",
@@ -243,7 +247,9 @@
           "callbacks": []
         }
       ],
-      "responseMode": null
+      "responseMode": null,
+      "streamingMode": null,
+      "streamingInterval": 0
     },
     {
       "uuid": "fe30c0a7-ccff-49a4-a07f-11ff6a73a245",
@@ -448,7 +454,9 @@
           "callbacks": []
         }
       ],
-      "responseMode": "RANDOM"
+      "responseMode": "RANDOM",
+      "streamingMode": null,
+      "streamingInterval": 0
     },
     {
       "uuid": "f3ab3915-89ad-4ee5-bc21-9d5daf66fe8d",
@@ -653,7 +661,9 @@
           "callbacks": []
         }
       ],
-      "responseMode": "RANDOM"
+      "responseMode": "RANDOM",
+      "streamingMode": null,
+      "streamingInterval": 0
     },
     {
       "uuid": "3244c7de-319e-417a-94fc-4479254f0e3b",
@@ -858,7 +868,9 @@
           "callbacks": []
         }
       ],
-      "responseMode": "RANDOM"
+      "responseMode": "RANDOM",
+      "streamingMode": null,
+      "streamingInterval": 0
     }
   ],
   "rootChildren": [

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -7,14 +7,14 @@ export default defineNuxtConfig({
     '@nuxtjs/i18n',
     '@sidebase/nuxt-auth',
   ],
-  devtools: { enabled: true },
+  devtools: { enabled: import.meta.env.DEV },
   app: {
     pageTransition: { name: 'page', mode: 'out-in' },
   },
   runtimeConfig: {
     authSecret: process.env.NUXT_AUTH_SECRET,
   },
-  sourcemap: true,
+  sourcemap: import.meta.env.DEV,
   devServer: {
     port: 4507,
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,14 +12,14 @@
         "@carbon/themes": "^10.55.3",
         "@carbon/vue": "^3.0.25",
         "@nuxt/eslint": "^1.3.0",
-        "@nuxtjs/i18n": "9.4.0",
+        "@nuxtjs/i18n": "^9.5.4",
         "@nuxtjs/tailwindcss": "^6.14.0",
         "@sidebase/nuxt-auth": "^0.10.1",
         "luxon": "^3.6.1",
         "next-auth": "~4.21.1",
         "nuxt": "^3.17.1",
-        "vue": "*",
-        "vue-router": "*",
+        "vue": "latest",
+        "vue-router": "latest",
         "winston": "^3.17.0"
       },
       "devDependencies": {
@@ -1611,12 +1611,12 @@
       }
     },
     "node_modules/@intlify/bundle-utils/node_modules/@intlify/message-compiler": {
-      "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-11.1.2.tgz",
-      "integrity": "sha512-T/xbNDzi+Yv0Qn2Dfz2CWCAJiwNgU5d95EhhAEf4YmOgjCKktpfpiUSmLcBvK1CtLpPQ85AMMQk/2NCcXnNj1g==",
+      "version": "11.1.3",
+      "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-11.1.3.tgz",
+      "integrity": "sha512-7rbqqpo2f5+tIcwZTAG/Ooy9C8NDVwfDkvSeDPWUPQW+Dyzfw2o9H103N5lKBxO7wxX9dgCDjQ8Umz73uYw3hw==",
       "license": "MIT",
       "dependencies": {
-        "@intlify/shared": "11.1.2",
+        "@intlify/shared": "11.1.3",
         "source-map-js": "^1.0.2"
       },
       "engines": {
@@ -1627,9 +1627,9 @@
       }
     },
     "node_modules/@intlify/bundle-utils/node_modules/@intlify/shared": {
-      "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-11.1.2.tgz",
-      "integrity": "sha512-dF2iMMy8P9uKVHV/20LA1ulFLL+MKSbfMiixSmn6fpwqzvix38OIc7ebgnFbBqElvghZCW9ACtzKTGKsTGTWGA==",
+      "version": "11.1.3",
+      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-11.1.3.tgz",
+      "integrity": "sha512-pTFBgqa/99JRA2H1qfyqv97MKWJrYngXBA/I0elZcYxvJgcCw3mApAoPW3mJ7vx3j+Ti0FyKUFZ4hWxdjKaxvA==",
       "license": "MIT",
       "engines": {
         "node": ">= 16"
@@ -1645,13 +1645,13 @@
       "license": "MIT"
     },
     "node_modules/@intlify/core": {
-      "version": "10.0.5",
-      "resolved": "https://registry.npmjs.org/@intlify/core/-/core-10.0.5.tgz",
-      "integrity": "sha512-wvjsNSpjulznpPs24ZmwvmcomUP6qvBvRt5YAplx5zaCqM7n5KbiZk4mlPl2GjPVYUIOLlyZb0CUFQ5UJB/DMA==",
+      "version": "10.0.7",
+      "resolved": "https://registry.npmjs.org/@intlify/core/-/core-10.0.7.tgz",
+      "integrity": "sha512-4n9tKt0/HcPrXfm0ceQlNC/wsgrrfXyHwRHSSiekMAy5vkOBc4PJXB5aUHGGkkH0dDdlkYyxUWqhZ3V64+gcKw==",
       "license": "MIT",
       "dependencies": {
-        "@intlify/core-base": "10.0.5",
-        "@intlify/shared": "10.0.5"
+        "@intlify/core-base": "10.0.7",
+        "@intlify/shared": "10.0.7"
       },
       "engines": {
         "node": ">= 16"
@@ -1661,13 +1661,13 @@
       }
     },
     "node_modules/@intlify/core-base": {
-      "version": "10.0.5",
-      "resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-10.0.5.tgz",
-      "integrity": "sha512-F3snDTQs0MdvnnyzTDTVkOYVAZOE/MHwRvF7mn7Jw1yuih4NrFYLNYIymGlLmq4HU2iIdzYsZ7f47bOcwY73XQ==",
+      "version": "10.0.7",
+      "resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-10.0.7.tgz",
+      "integrity": "sha512-mE71aUH5baH0me8duB4FY5qevUJizypHsYw3eCvmOx07QvmKppgOONx3dYINxuA89Z2qkAGb/K6Nrpi7aAMwew==",
       "license": "MIT",
       "dependencies": {
-        "@intlify/message-compiler": "10.0.5",
-        "@intlify/shared": "10.0.5"
+        "@intlify/message-compiler": "10.0.7",
+        "@intlify/shared": "10.0.7"
       },
       "engines": {
         "node": ">= 16"
@@ -1693,12 +1693,12 @@
       }
     },
     "node_modules/@intlify/message-compiler": {
-      "version": "10.0.5",
-      "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-10.0.5.tgz",
-      "integrity": "sha512-6GT1BJ852gZ0gItNZN2krX5QAmea+cmdjMvsWohArAZ3GmHdnNANEcF9JjPXAMRtQ6Ux5E269ymamg/+WU6tQA==",
+      "version": "10.0.7",
+      "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-10.0.7.tgz",
+      "integrity": "sha512-nrC4cDL/UHZSUqd8sRbVz+DPukzZ8NnG5OK+EB/nlxsH35deyzyVkXP/QuR8mFZrISJ+4hCd6VtCQCcT+RO+5g==",
       "license": "MIT",
       "dependencies": {
-        "@intlify/shared": "10.0.5",
+        "@intlify/shared": "10.0.7",
         "source-map-js": "^1.0.2"
       },
       "engines": {
@@ -1709,9 +1709,9 @@
       }
     },
     "node_modules/@intlify/shared": {
-      "version": "10.0.5",
-      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-10.0.5.tgz",
-      "integrity": "sha512-bmsP4L2HqBF6i6uaMqJMcFBONVjKt+siGluRq4Ca4C0q7W2eMaVZr8iCgF9dKbcVXutftkC7D6z2SaSMmLiDyA==",
+      "version": "10.0.7",
+      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-10.0.7.tgz",
+      "integrity": "sha512-oeoq0L5+5P4ShXa6jBQcx+BT+USe3MjX0xJexZO1y7rfDJdwZ9+QP3jO4tcS1nxhBYYdjvFTqe4bmnLijV0GxQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 16"
@@ -1721,9 +1721,9 @@
       }
     },
     "node_modules/@intlify/unplugin-vue-i18n": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/@intlify/unplugin-vue-i18n/-/unplugin-vue-i18n-6.0.5.tgz",
-      "integrity": "sha512-0MKaYhLvM46Mtm+OArkK75ztmqaFfhIvnm5mg8XKqCPAKVAK98o+8tB6gUQFkKrF5PMYsNXvyMJCi40cRCDJbA==",
+      "version": "6.0.8",
+      "resolved": "https://registry.npmjs.org/@intlify/unplugin-vue-i18n/-/unplugin-vue-i18n-6.0.8.tgz",
+      "integrity": "sha512-Vvm3KhjE6TIBVUQAk37rBiaYy2M5OcWH0ZcI1XKEsOTeN1o0bErk+zeuXmcrcMc/73YggfI8RoxOUz9EB/69JQ==",
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
@@ -1761,9 +1761,9 @@
       }
     },
     "node_modules/@intlify/unplugin-vue-i18n/node_modules/@intlify/shared": {
-      "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-11.1.2.tgz",
-      "integrity": "sha512-dF2iMMy8P9uKVHV/20LA1ulFLL+MKSbfMiixSmn6fpwqzvix38OIc7ebgnFbBqElvghZCW9ACtzKTGKsTGTWGA==",
+      "version": "11.1.3",
+      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-11.1.3.tgz",
+      "integrity": "sha512-pTFBgqa/99JRA2H1qfyqv97MKWJrYngXBA/I0elZcYxvJgcCw3mApAoPW3mJ7vx3j+Ti0FyKUFZ4hWxdjKaxvA==",
       "license": "MIT",
       "engines": {
         "node": ">= 16"
@@ -4136,17 +4136,17 @@
       }
     },
     "node_modules/@nuxtjs/i18n": {
-      "version": "9.4.0",
-      "resolved": "https://registry.npmjs.org/@nuxtjs/i18n/-/i18n-9.4.0.tgz",
-      "integrity": "sha512-WREUig3PIdlcd3WbfRtmPx9HoLTUB7vUnbUvPS48O/qebntvAtlJKWjxaaBKpFof1RfbGmvPwtmEt+sYdJ6N3w==",
+      "version": "9.5.4",
+      "resolved": "https://registry.npmjs.org/@nuxtjs/i18n/-/i18n-9.5.4.tgz",
+      "integrity": "sha512-HSCC6bLvkI74AOJ/Hsa8+52uy92Bzpu/lVOKYJZIR/HV4TtV48fgKLPRlL8RmCXx/AmKBtrPsLfhAAIj9RBAKQ==",
       "license": "MIT",
       "dependencies": {
         "@intlify/h3": "^0.6.1",
-        "@intlify/shared": "^10.0.6",
-        "@intlify/unplugin-vue-i18n": "^6.0.5",
+        "@intlify/shared": "^10.0.7",
+        "@intlify/unplugin-vue-i18n": "^6.0.8",
         "@intlify/utils": "^0.13.0",
         "@miyaneee/rollup-plugin-json5": "^1.2.0",
-        "@nuxt/kit": "^3.16.1",
+        "@nuxt/kit": "^3.16.2",
         "@oxc-parser/wasm": "^0.60.0",
         "@rollup/plugin-yaml": "^4.1.2",
         "@vue/compiler-sfc": "^3.5.13",
@@ -4154,7 +4154,7 @@
         "defu": "^6.1.4",
         "esbuild": "^0.25.1",
         "estree-walker": "^3.0.3",
-        "is-https": "^4.0.0",
+        "h3": "^1.15.1",
         "knitwork": "^1.2.0",
         "magic-string": "^0.30.17",
         "mlly": "^1.7.4",
@@ -4164,7 +4164,7 @@
         "ufo": "^1.5.4",
         "unplugin": "^2.2.2",
         "unplugin-vue-router": "^0.12.0",
-        "vue-i18n": "^10.0.6",
+        "vue-i18n": "^10.0.7",
         "vue-router": "^4.5.0"
       },
       "engines": {
@@ -4174,31 +4174,32 @@
         "url": "https://github.com/sponsors/bobbiegoede"
       }
     },
-    "node_modules/@nuxtjs/i18n/node_modules/@intlify/shared": {
-      "version": "10.0.7",
-      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-10.0.7.tgz",
-      "integrity": "sha512-oeoq0L5+5P4ShXa6jBQcx+BT+USe3MjX0xJexZO1y7rfDJdwZ9+QP3jO4tcS1nxhBYYdjvFTqe4bmnLijV0GxQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/kazupon"
-      }
-    },
     "node_modules/@nuxtjs/i18n/node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "license": "MIT"
     },
+    "node_modules/@nuxtjs/i18n/node_modules/picomatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/@nuxtjs/i18n/node_modules/unplugin": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-2.2.2.tgz",
-      "integrity": "sha512-Qp+iiD+qCRnUek+nDoYvtWX7tfnYyXsrOnJ452FRTgOyKmTM7TUJ3l+PLPJOOWPTUyKISKp4isC5JJPSXUjGgw==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-2.3.2.tgz",
+      "integrity": "sha512-3n7YA46rROb3zSj8fFxtxC/PqoyvYQ0llwz9wtUPUutr9ig09C8gGo5CWCwHrUzlqC1LLR43kxp5vEIyH1ac1w==",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.14.1",
+        "picomatch": "^4.0.2",
         "webpack-virtual-modules": "^0.6.2"
       },
       "engines": {
@@ -11554,12 +11555,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/is-https": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/is-https/-/is-https-4.0.0.tgz",
-      "integrity": "sha512-FeMLiqf8E5g6SdiVJsPcNZX8k4h2fBs1wp5Bb6uaNxn58ufK1axBqQZdmAQsqh0t9BuwFObybrdVJh6MKyPlyg==",
-      "license": "MIT"
     },
     "node_modules/is-inside-container": {
       "version": "1.0.0",
@@ -19150,13 +19145,13 @@
       }
     },
     "node_modules/vue-i18n": {
-      "version": "10.0.6",
-      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-10.0.6.tgz",
-      "integrity": "sha512-pQPspK5H4srzlu+47+HEY2tmiY3GyYIvSPgSBdQaYVWv7t1zj1t9p1FvHlxBXyJ17t9stG/Vxj+pykrvPWBLeQ==",
+      "version": "10.0.7",
+      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-10.0.7.tgz",
+      "integrity": "sha512-bKsk0PYwP9gdYF4nqSAT0kDpnLu1gZzlxFl885VH4mHVhEnqP16+/mAU05r1U6NIrc0fGDWP89tZ8GzeJZpe+w==",
       "license": "MIT",
       "dependencies": {
-        "@intlify/core-base": "10.0.6",
-        "@intlify/shared": "10.0.6",
+        "@intlify/core-base": "10.0.7",
+        "@intlify/shared": "10.0.7",
         "@vue/devtools-api": "^6.5.0"
       },
       "engines": {
@@ -19167,50 +19162,6 @@
       },
       "peerDependencies": {
         "vue": "^3.0.0"
-      }
-    },
-    "node_modules/vue-i18n/node_modules/@intlify/core-base": {
-      "version": "10.0.6",
-      "resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-10.0.6.tgz",
-      "integrity": "sha512-/NINGvy7t8qSCyyuqMIPmHS6CBQjqPIPVOps0Rb7xWrwwkwHJKtahiFnW1HC4iQVhzoYwEW6Js0923zTScLDiA==",
-      "license": "MIT",
-      "dependencies": {
-        "@intlify/message-compiler": "10.0.6",
-        "@intlify/shared": "10.0.6"
-      },
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/kazupon"
-      }
-    },
-    "node_modules/vue-i18n/node_modules/@intlify/message-compiler": {
-      "version": "10.0.6",
-      "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-10.0.6.tgz",
-      "integrity": "sha512-QcUYprK+e4X2lU6eJDxLuf/mUtCuVPj2RFBoFRlJJxK3wskBejzlRvh1Q0lQCi9tDOnD4iUK1ftcGylE3X3idA==",
-      "license": "MIT",
-      "dependencies": {
-        "@intlify/shared": "10.0.6",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/kazupon"
-      }
-    },
-    "node_modules/vue-i18n/node_modules/@intlify/shared": {
-      "version": "10.0.6",
-      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-10.0.6.tgz",
-      "integrity": "sha512-2xqwm05YPpo7TM//+v0bzS0FWiTzsjpSMnWdt7ZXs5/ZfQIedSuBXIrskd8HZ7c/cZzo1G9ALHTksnv/74vk/Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/kazupon"
       }
     },
     "node_modules/vue-router": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@carbon/themes": "^10.55.3",
     "@carbon/vue": "^3.0.25",
     "@nuxt/eslint": "^1.3.0",
-    "@nuxtjs/i18n": "9.4.0",
+    "@nuxtjs/i18n": "^9.5.4",
     "@nuxtjs/tailwindcss": "^6.14.0",
     "@sidebase/nuxt-auth": "^0.10.1",
     "luxon": "^3.6.1",


### PR DESCRIPTION
- Upgrading to the latest @nuxtjs/i18n required `npm remove @nuxtjs/i18n` and `npm install @nuxtjs/i18n`
- Added Mockoon to local dev docker compose file
- Schedule trivy security scans for Wednesdays